### PR TITLE
Update DESCRIPTION using non-versioned Boost URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,9 +5,9 @@ Authors@R:
     person(c("Andrew", "R."), "Johnson", , "andrew.johnson@arjohnsonau.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7000-8065"))
 Description: 'R' bindings for the various functions and statistical distributions
-    provided by the 'Boost' Math library <https://www.boost.org/doc/libs/boost_1_88_0/libs/math/doc/html/index.html>.
+    provided by the 'Boost' Math library <https://www.boost.org/doc/libs/latest/libs/math/doc/html/index.html>.
 License: MIT + file LICENSE
-URL: https://github.com/andrjohns/boostmath, https://www.boost.org/doc/libs/boost_1_88_0/libs/math/doc/html/index.html
+URL: https://github.com/andrjohns/boostmath, https://www.boost.org/doc/libs/latest/libs/math/doc/html/index.html
 BugReports: https://github.com/andrjohns/boostmath/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Boost also has URLs that do not encode the version number, using these may be preferable as the link cannot get stale over time.